### PR TITLE
Revert "Pack extension and add instead of loading unpacked"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,8 @@
 ### This extension may conflict with dev version of Secure Shell extension, you may need to remove dev version of Secure Shell (if installed)
 
 - Download [archive](https://github.com/supechicken/ChromeOS-AutoStart/archive/main.zip) of this repository and unzip it
-- Unpack the zip file by:
-  - Double click the zip file in the file manager. The zip file will show contents in what looks like a flash drive
-  - Drag the folder within the zip file into the Downloads folder
-  - Optionally delete the zip file
-- Go to [chrome://extensions](chrome://extensions) and enable Developer Mode
-- Click "Pack Extension", click "Browse" under "Extension Root Directory", then click on the folder named `ChromeOS-AutoStart-main`, and click "Open"
-- Click "Pack Extension", then click "Okay"
-- Open the file manager, go to Downloads and drag the `.crx` file into the chrome://extensions window.
-- Click "Add Extension"
-- Optionally delete the generated `.crx` packaged file and `.pem` key file
+- Go to chrome://extensions/ and enable Developer Mode
+- Click `Load unpacked extension` and select the `ChromeOS-AutoStart-main` unzipped folder
+- A new window will appear and type the command you want to run it at startup
+- Optional: Click the `Test` button to test it out after setting a command
+- Reboot and enjoy :)


### PR DESCRIPTION
Reverts supechicken/ChromeOS-AutoStart#1

See #2

Loading from crx doesn’t support id customisation